### PR TITLE
fixing date formatting

### DIFF
--- a/chip-var.cwl
+++ b/chip-var.cwl
@@ -233,5 +233,5 @@ $schemas:
     's:email': 'mailto:shahr@mskcc.org'
     's:identifier': ''
     's:name': Ronak Shah
-'s:dateCreated': 2020-11-3
+'s:dateCreated': '2020-11-3'
 's:license': 'https://spdx.org/licenses/Apache-2.0'


### PR DESCRIPTION
The date formatting was breaking Voyager's cwlpack command. This resulted in the pipeline failing to submit to ridgeback. 

example failed pack: 
```
{
                                    "class": "s:Person",
                                    "s:email": "mailto:shahr@mskcc.org",
                                    "s:identifier": "",
                                    "s:name": "Ronak Shah"
                                }
                            ],
                            "s:dateCreated": Traceback (most recent call last):
  File "/usr/local/bin/cwlpack", line 8, in <module>
    sys.exit(localpack())
  File "/usr/local/lib/python3.9/dist-packages/sbpack/pack.py", line 426, in localpack
    _localpack(sys.argv[1:])
  File "/usr/local/lib/python3.9/dist-packages/sbpack/pack.py", line 458, in _localpack
    json.dump(cwl, sys.stdout, indent=4)
  File "/usr/lib/python3.9/json/__init__.py", line 179, in dump
    for chunk in iterable:
  File "/usr/lib/python3.9/json/encoder.py", line 431, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/lib/python3.9/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.9/json/encoder.py", line 325, in _iterencode_list
    yield from chunks
  File "/usr/lib/python3.9/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.9/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.9/json/encoder.py", line 325, in _iterencode_list
    yield from chunks
  File "/usr/lib/python3.9/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.9/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.9/json/encoder.py", line 438, in _iterencode
    o = _default(o)
  File "/usr/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type date is not JSON serializable
```

You can check a failing cwlpack on Voyager with: 
```
module load singularity/3.3.0
source env_beagle.sh
singularity shell instance://dev_beagle
cwlpack /tmp/4591528e-babc-4db8-a252-88eed547575a/chip-var/chip-var.cwl --json
```